### PR TITLE
adding random seed functionality

### DIFF
--- a/vsm/model/_cgs_update.pyx
+++ b/vsm/model/_cgs_update.pyx
@@ -11,7 +11,8 @@ def cgs_update(int itr,
                np.ndarray[np.float64_t, negative_indices=False] inv_top_sums,
                np.ndarray[np.float64_t, negative_indices=False, ndim=2] top_doc,
                np.ndarray[long, negative_indices=False] Z,
-               np.ndarray[long, negative_indices=False] indices):
+               np.ndarray[long, negative_indices=False] indices,
+               int seed):
 
     cdef int V = corpus.shape[0]
     cdef int N = indices.shape[0]
@@ -23,8 +24,11 @@ def cgs_update(int itr,
     cdef np.ndarray[np.float64_t, ndim=2, negative_indices=False, mode='c']\
         log_kd = np.log(top_doc / top_doc.sum(0)[np.newaxis, :])
 
+    # load a seeded random number generator
+    rstate = np.random.RandomState(seed)
     cdef np.ndarray[np.float64_t, negative_indices=False, mode='c']\
-        samples = np.random.random(V)
+        samples = rstate.random_sample(V)
+        # samples = np.random.random(V) # The original random generator
 
     cdef double r, s
     cdef long start, stop, doc_len, offset

--- a/vsm/model/ldacgsseq.py
+++ b/vsm/model/ldacgsseq.py
@@ -15,7 +15,7 @@ class LdaCgsSeq(object):
     """
     """
     def __init__(self, corpus=None, context_type=None,
-                 K=20, V=0, alpha=[], beta=[]):
+                 K=20, V=0, alpha=[], beta=[], seed=0):
         """
         Initialize LdaCgsSeq.
 
@@ -39,6 +39,7 @@ class LdaCgsSeq(object):
 
         self.context_type = context_type
         self.K = K
+        self.seed = seed
 
         if corpus:
             self.V = corpus.words.size
@@ -94,7 +95,7 @@ class LdaCgsSeq(object):
 
             results = cgs_update(self.iteration, self.corpus, self.word_top,
                                  self.inv_top_sums, self.top_doc, self.Z, 
-                                 self.indices)
+                                 self.indices, self.seed)
 
             lp = results[4]
             self.log_probs.append((self.iteration, lp))

--- a/vsm/model/ldafunctions.py
+++ b/vsm/model/ldafunctions.py
@@ -24,20 +24,19 @@ def init_priors(V=0, K=0, beta=[], alpha=[]):
     return beta, alpha
 
 
-def categorical(pvals, random_state=None):
+def categorical(pvals, random_seed=0):
     """
     Draws a sample from the categorical distribution parameterized by
     `pvals`.
     """
-    if not random_state:
-        random_state = np.random.RandomState()
+    random_state = np.random.RandomState(random_seed)
     cum_dist = np.cumsum(pvals)
     r = random_state.uniform() * cum_dist[-1]
     return np.searchsorted(cum_dist, r)
 
 
 def cgs_update(itr, docs, word_top, inv_top_sums, 
-               top_doc, Z, random_state=None):
+               top_doc, Z, indices=None, random_seed=0):
 
     log_p = 0
     log_wk = np.log(word_top * inv_top_sums[np.newaxis, :])
@@ -57,7 +56,7 @@ def cgs_update(itr, docs, word_top, inv_top_sums,
 
             dist = inv_top_sums * word_top[w,:] * top_doc[:,i]
 
-            k = categorical(dist, random_state=random_state)
+            k = categorical(dist, random_seed=random_seed)
 
             word_top[w, k] += 1
             inv_top_sums[k] *= 1. / (1 + inv_top_sums[k]) 


### PR DESCRIPTION
This functionality is made to match a behavior that was factored out, enabling experiments on different seeds for the random number generators. I was unsure of the line initializing `rstate` in `vsm/model/_cgs_update.pyx`, as I have not worked in cython before.

Throughout the implementation I had to use a default value of 0, since cython would not accept "None" for `int seed`. Additionally, I added the functionality back to the original `ldafunctions.cgs_update()` and added the `indicies` kwarg, enabling the two commands (cython and native python) to be switched easily.

The pull request should be merged into general-refactoring first, and should be properly marked in GitHub.
